### PR TITLE
added flags for runtime usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,15 +1,33 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+
 	"github.com/RonnanSouza/kafka_environment/consumer"
 	"github.com/RonnanSouza/kafka_environment/producer"
-	"os"
 )
 
-func main()  {
-	if os.Args[1] == "consumer" {
-		consumer.StartConsumer()
-	} else if os.Args[1] == "producer" {
+func main() {
+
+	// Flags
+	consumerFlagValue := flag.Bool("c", false, "    Use this flag to start a Kafka Consumer")
+	producerFlagValue := flag.Bool("p", false, "    Use this flag to start a Kafka Producer")
+	stringFlagValue := flag.String("a", "", "    Use this flag with either \"consumer\" or \"producer\"")
+
+	// Flag Processing
+	flag.Parse()
+
+	// Decision Time
+	if *producerFlagValue == true {
 		producer.StartProducer()
+	} else if *consumerFlagValue == true {
+		consumer.StartConsumer()
+	} else if *stringFlagValue == "consumer" {
+		consumer.StartConsumer()
+	} else if *stringFlagValue == "producer" {
+		producer.StartProducer()
+	} else {
+		fmt.Print("Usage: \n -c     Use this flag to start a Kafka Consumer\n -p     Use this flag to start a Kafka Producer\n -a     Use this flag with either \"consumer\" or \"producer\"\n")
 	}
 }


### PR DESCRIPTION
```
$ go run main.go                           
Usage: 
 -c     Use this flag to start a Kafka Consumer
 -p     Use this flag to start a Kafka Producer
 -a     Use this flag with either "consumer" or "producer"
```


```
$ go run main.go -h
Usage of /tmp/go-build249707848/b001/exe/main:
  -a string
            Use this flag with either "consumer" or "producer"
  -c        Use this flag to start a Kafka Consumer
  -p        Use this flag to start a Kafka Producer
 ```